### PR TITLE
Some small fixes for filepath.Walk

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -268,6 +268,14 @@ func deleteOldestFile(path string) error {
 	lastMod := time.Now()
 
 	err := filepath.Walk(path, func(file string, info os.FileInfo, err error) error {
+		if err != nil {
+			Log.Errorf("Error during walk through cache directory: %+v", err)
+			return filepath.SkipDir
+		}
+		if info == nil {
+			Log.Errorf("File info for %s was nil", file)
+			return filepath.SkipDir
+		}
 		if !info.IsDir() {
 			modTime := info.ModTime()
 			if modTime.Before(lastMod) {


### PR DESCRIPTION
This adds some more logging to filepath.Walk when trying to find the oldest chunk. Also this fix checks now if os.FileInfo is nil (seems like it could be) and logs this condition. At least in my case these changes fix #134 for me.