### PR TITLE
Errors are now reported with error level.

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -161,14 +161,14 @@ func (b *Buffer) ReadBytes(start, size int64, preload bool, delay int32) ([]byte
 			return buf[:size], nil
 		}
 
-		Log.Debugf("%v", err)
-		Log.Debugf("Could not read file %s at %v", filename, fOffset)
+		Log.Errorf("%v", err)
+		Log.Errorf("Could not read file %s at %v", filename, fOffset)
 	}
 
 	if chunkDirMaxSize > 0 {
 		go func() {
 			if err := cleanChunkDir(chunkPath); nil != err {
-				Log.Debugf("%v", err)
+				Log.Errorf("%v", err)
 				Log.Warningf("Could not delete oldest chunk")
 			}
 		}()
@@ -182,7 +182,7 @@ func (b *Buffer) ReadBytes(start, size int64, preload bool, delay int32) ([]byte
 	Log.Debugf("Requesting object %v bytes %v - %v from API", b.object.ObjectID, offset, offsetEnd)
 	req, err := http.NewRequest("GET", b.object.DownloadURL, nil)
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return nil, fmt.Errorf("Could not create request object %v from API", b.object.ObjectID)
 	}
 
@@ -192,7 +192,7 @@ func (b *Buffer) ReadBytes(start, size int64, preload bool, delay int32) ([]byte
 
 	res, err := b.client.Do(req)
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return nil, fmt.Errorf("Could not request object %v from API", b.object.ObjectID)
 	}
 	defer res.Body.Close()
@@ -213,7 +213,7 @@ func (b *Buffer) ReadBytes(start, size int64, preload bool, delay int32) ([]byte
 		}
 		bytes, err := ioutil.ReadAll(reader)
 		if nil != err {
-			Log.Debugf("%v", err)
+			Log.Errorf("%v", err)
 			return nil, fmt.Errorf("Could not read body of 403 error")
 		}
 		body := string(bytes)
@@ -232,19 +232,19 @@ func (b *Buffer) ReadBytes(start, size int64, preload bool, delay int32) ([]byte
 
 	bytes, err := ioutil.ReadAll(reader)
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return nil, fmt.Errorf("Could not read objects %v API response", b.object.ObjectID)
 	}
 
 	if _, err := os.Stat(b.tempDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(b.tempDir, 0777); nil != err {
-			Log.Debugf("%v", err)
-			return nil, fmt.Errorf("Could not create chunk temp path for chunk %v", filename)
+			Log.Errorf("%v", err)
+			return nil, fmt.Errorf("Could not create chunk temp path for chunk %v: Error: %+v", filename)
 		}
 	}
 
 	if err := ioutil.WriteFile(filename, bytes, 0777); nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		Log.Warningf("Could not write chunk temp file %v", filename)
 	}
 

--- a/cache.go
+++ b/cache.go
@@ -99,7 +99,7 @@ func (c *Cache) Close() error {
 
 	close(c.dbAction)
 	if err := c.db.Close(); nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return fmt.Errorf("Could not close cache connection")
 	}
 
@@ -112,7 +112,7 @@ func (c *Cache) LoadToken() (*oauth2.Token, error) {
 
 	tokenFile, err := ioutil.ReadFile(c.tokenPath)
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return nil, fmt.Errorf("Could not read token file in %v", c.tokenPath)
 	}
 
@@ -130,12 +130,12 @@ func (c *Cache) StoreToken(token *oauth2.Token) error {
 
 	tokenJSON, err := json.Marshal(token)
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return fmt.Errorf("Could not generate token.json content")
 	}
 
 	if err := ioutil.WriteFile(c.tokenPath, tokenJSON, 0644); nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return fmt.Errorf("Could not generate token.json file")
 	}
 

--- a/clean.go
+++ b/clean.go
@@ -60,6 +60,14 @@ func clearByInterval(chunkDir string, clearInterval, chunkAge time.Duration) {
 // deleteEmptyDirs deletes empty directories
 func deleteEmptyDirs(dir string) error {
 	err := filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			Log.Errorf("Error during file walk: %+v", err)
+			return filepath.SkipDir
+		}
+		if f == nil {
+			Log.Errorf("File info is nil during file walkd")
+			return filepath.SkipDir
+		}
 		if f.IsDir() {
 			if empty, err := isEmptyDir(path); nil == err && empty {
 				Log.Debugf("Cleaning empty directory %v", path)

--- a/config.go
+++ b/config.go
@@ -37,23 +37,23 @@ func CreateConfig(configPath string) (*Config, error) {
 	fmt.Printf("7. Enter your generated client ID: ")
 	var config Config
 	if _, err := fmt.Scan(&config.ClientID); err != nil {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return nil, fmt.Errorf("Unable to read client id")
 	}
 	fmt.Printf("8. Enter your generated client secret: ")
 	if _, err := fmt.Scan(&config.ClientSecret); err != nil {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return nil, fmt.Errorf("Unable to read client secret")
 	}
 
 	configJSON, err := json.Marshal(&config)
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return nil, fmt.Errorf("Could not generate config.json content")
 	}
 
 	if err := ioutil.WriteFile(configPath, configJSON, 0766); nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return nil, fmt.Errorf("Could not generate config.json file")
 	}
 

--- a/drive.go
+++ b/drive.go
@@ -72,7 +72,7 @@ func NewDriveClient(config *Config, cache *Cache, refreshInterval time.Duration)
 func (d *Drive) startWatchChanges(refreshInterval time.Duration) {
 	client, err := d.getClient()
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		Log.Warningf("Could not get Google Drive client to watch for changes")
 		return
 	}
@@ -105,7 +105,7 @@ func (d *Drive) startWatchChanges(refreshInterval time.Duration) {
 
 			results, err := query.Do()
 			if nil != err {
-				Log.Debugf("%v", err)
+				Log.Errorf("%v", err)
 				Log.Warningf("Could not get changes")
 				break
 			}
@@ -217,7 +217,7 @@ func (d *Drive) GetRoot() (*APIObject, error) {
 
 	client, err := d.getClient()
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return nil, fmt.Errorf("Could not get Google Drive client")
 	}
 
@@ -234,7 +234,7 @@ func (d *Drive) GetRoot() (*APIObject, error) {
 	if file.MimeType != "application/vnd.google-apps.folder" && 0 == file.Size {
 		res, err := client.Files.Get(id).Download()
 		if nil != err {
-			Log.Debugf("%v", err)
+			Log.Errorf("%v", err)
 			return nil, fmt.Errorf("Could not get file size for object %v", id)
 		}
 		file.Size = res.ContentLength
@@ -272,17 +272,17 @@ func (d *Drive) Open(object *APIObject) (*Buffer, error) {
 func (d *Drive) Remove(object *APIObject) error {
 	client, err := d.getClient()
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return fmt.Errorf("Could not get Google Drive client")
 	}
 
 	if err := client.Files.Delete(object.ObjectID).Do(); nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return fmt.Errorf("Could not delete object %v from API", object.Name)
 	}
 
 	if err := d.cache.DeleteObject(object.ObjectID); nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return fmt.Errorf("Could not delete object %v from cache", object.Name)
 	}
 
@@ -295,7 +295,7 @@ func (d *Drive) mapFileToObject(file *gdrive.File) (*APIObject, error) {
 
 	lastModified, err := time.Parse(time.RFC3339, file.ModifiedTime)
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		Log.Warningf("Could not parse last modified date for object %v", file.Id)
 		lastModified = time.Now()
 	}

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func main() {
 		config, err = CreateConfig(configPath)
 		if nil != err {
 			Log.Errorf("Could not read configuration")
-			Log.Debugf("%v", err)
+			Log.Errorf("%v", err)
 			os.Exit(3)
 		}
 	}
@@ -155,7 +155,7 @@ func main() {
 	cache, err := NewCache(*argConfigPath, *argLogLevel > 3)
 	if nil != err {
 		Log.Errorf("Could not initialize cache")
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		os.Exit(4)
 	}
 	defer cache.Close()
@@ -163,7 +163,7 @@ func main() {
 	drive, err := NewDriveClient(config, cache, *argRefreshInterval)
 	if nil != err {
 		Log.Errorf("Could not initialize Google Drive Client")
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		os.Exit(4)
 	}
 
@@ -171,7 +171,7 @@ func main() {
 	checkOsSignals(argMountPoint)
 	go CleanChunkDir(chunkPath, *argClearInterval, *argClearChunkAge, clearMaxChunkSize)
 	if err := Mount(drive, argMountPoint, mountOptions, uid, gid, umask); nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		os.Exit(5)
 	}
 }
@@ -216,7 +216,7 @@ func parseSizeArg(input string) (int64, error) {
 	input = input[:len(input)-suffixLen]
 	value, err := strconv.ParseFloat(input, 64)
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return 0, fmt.Errorf("Could not parse numeric value %v", input)
 	}
 	if value < 0 {

--- a/mount.go
+++ b/mount.go
@@ -22,7 +22,7 @@ func Mount(client *Drive, mountpoint string, mountOptions []string, uid, gid uin
 	if _, err := os.Stat(mountpoint); os.IsNotExist(err) {
 		Log.Debugf("Mountpoint doesn't exist, creating...")
 		if err := os.MkdirAll(mountpoint, 0644); nil != err {
-			Log.Debugf("%v", err)
+			Log.Errorf("%v", err)
 			return fmt.Errorf("Could not create mount directory %v", mountpoint)
 		}
 	}
@@ -51,7 +51,7 @@ func Mount(client *Drive, mountpoint string, mountOptions []string, uid, gid uin
 			data := strings.Split(option, "=")
 			value, err := strconv.ParseUint(data[1], 10, 32)
 			if nil != err {
-				Log.Debugf("%v", err)
+				Log.Errorf("%v", err)
 				return fmt.Errorf("Could not parse max_readahead value")
 			}
 			options = append(options, fuse.MaxReadahead(uint32(value)))
@@ -95,7 +95,7 @@ func Mount(client *Drive, mountpoint string, mountOptions []string, uid, gid uin
 	// check if the mount process has an error to report
 	<-c.Ready
 	if err := c.MountError; nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return fmt.Errorf("Error mounting FUSE")
 	}
 
@@ -177,7 +177,7 @@ func (o *Object) Attr(ctx context.Context, attr *fuse.Attr) error {
 func (o *Object) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 	objects, err := o.client.GetObjectsByParent(o.object.ObjectID)
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return nil, fuse.ENOENT
 	}
 
@@ -195,7 +195,7 @@ func (o *Object) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 func (o *Object) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	object, err := o.client.GetObjectByParentAndName(o.object.ObjectID, name)
 	if nil != err {
-		Log.Debugf("%v", err)
+		Log.Errorf("%v", err)
 		return nil, fuse.ENOENT
 	}
 


### PR DESCRIPTION
I switched logging of error from debug to error. At least for this is more convenient. I don't want to run plexdrive with debug logging all the time, but sometimes things go wrong (outside the control of plexdrive). In this case I just want to see the error in the log, without having to restart plexdrive in debug mode and trying to recreate some strange error condition.