### PR TITLE
[WIP] Use Bolt as a cache backend

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -27,6 +27,12 @@ const (
 	DeleteAction = iota
 )
 
+var (
+	bObjects   = []byte("api_objects")
+	bParents   = []byte("idx_api_objects_py_parent")
+	bPageToken = []byte("page_token")
+)
+
 type cacheAction struct {
 	action  int
 	object  *APIObject
@@ -62,13 +68,13 @@ func NewCache(cacheBasePath string) (*Cache, error) {
 
 	// Make sure the necessary buckets exist
 	err = db.Update(func(tx *bolt.Tx) error {
-		if _, err := tx.CreateBucketIfNotExists([]byte("api_objects")); nil != err {
+		if _, err := tx.CreateBucketIfNotExists(bObjects); nil != err {
 			return err
 		}
-		if _, err := tx.CreateBucketIfNotExists([]byte("idx_api_objects_by_parent")); nil != err {
+		if _, err := tx.CreateBucketIfNotExists(bParents); nil != err {
 			return err
 		}
-		if _, err := tx.CreateBucketIfNotExists([]byte("page_token")); nil != err {
+		if _, err := tx.CreateBucketIfNotExists(bPageToken); nil != err {
 			return err
 		}
 		return nil
@@ -121,26 +127,19 @@ func (c *Cache) StoreToken(token *oauth2.Token) error {
 }
 
 // GetObject gets an object by id
-func (c *Cache) GetObject(id string) (*APIObject, error) {
+func (c *Cache) GetObject(id string) (object *APIObject, err error) {
 	Log.Tracef("Getting object %v", id)
 
-	var v []byte
 	c.db.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("api_objects"))
-		v = b.Get([]byte(id))
+		object, err = boltGetObject(tx, id)
 		return nil
 	})
-	if nil == v {
-		return nil, fmt.Errorf("Could not find object %v in cache", id)
-	}
-
-	var object APIObject
-	if err := json.Unmarshal(v, &object); nil != err {
+	if nil != err {
 		return nil, err
 	}
 
 	Log.Tracef("Got object from cache %v", object)
-	return &object, nil
+	return object, err
 }
 
 // GetObjectsByParent get all objects under parent id
@@ -149,7 +148,7 @@ func (c *Cache) GetObjectsByParent(parent string) ([]*APIObject, error) {
 
 	objects := make([]*APIObject, 0)
 	c.db.View(func(tx *bolt.Tx) error {
-		cr := tx.Bucket([]byte("idx_api_objects_by_parent")).Cursor()
+		cr := tx.Bucket(bParents).Cursor()
 
 		// Iterate over all object ids stored under the parent in the index
 		objectIds := make([]string, 0)
@@ -159,14 +158,10 @@ func (c *Cache) GetObjectsByParent(parent string) ([]*APIObject, error) {
 		}
 
 		// Fetch all objects for the given ids
-		b := tx.Bucket([]byte("api_objects"))
 		for _, id := range objectIds {
-			var object APIObject
-			v := b.Get([]byte(id))
-			if err := json.Unmarshal(v, &object); nil != err {
-				panic(err)
+			if object, err := boltGetObject(tx, id); nil == err {
+				objects = append(objects, object)
 			}
-			objects = append(objects, &object)
 		}
 		return nil
 	})
@@ -176,27 +171,24 @@ func (c *Cache) GetObjectsByParent(parent string) ([]*APIObject, error) {
 }
 
 // GetObjectByParentAndName finds a child element by name and its parent id
-func (c *Cache) GetObjectByParentAndName(parent, name string) (*APIObject, error) {
+func (c *Cache) GetObjectByParentAndName(parent, name string) (object *APIObject, err error) {
 	Log.Tracef("Getting object %v in parent %v", name, parent)
 
-	var object *APIObject
 	c.db.View(func(tx *bolt.Tx) error {
 		// Look up object id in parent-name index
-		b := tx.Bucket([]byte("idx_api_objects_by_parent"))
+		b := tx.Bucket(bParents)
 		v := b.Get([]byte(parent + "/" + name))
 		if nil == v {
 			return nil
 		}
 
 		// Fetch object for given id
-		id := string(v)
-		b = tx.Bucket([]byte("api_objects"))
-		v = b.Get([]byte(id))
-		if err := json.Unmarshal(v, &object); nil != err {
-			panic(err)
-		}
+		object, err = boltGetObject(tx, string(v))
 		return nil
 	})
+	if nil != err {
+		return nil, err
+	}
 
 	if object == nil {
 		return nil, fmt.Errorf("Could not find object with name %v in parent %v", name, parent)
@@ -209,22 +201,16 @@ func (c *Cache) GetObjectByParentAndName(parent, name string) (*APIObject, error
 // DeleteObject deletes an object by id
 func (c *Cache) DeleteObject(id string) error {
 	err := c.db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("api_objects"))
-		v := b.Get([]byte(id))
-		if nil == v {
-			// No object found in cache? No cleanup necessary
+		b := tx.Bucket(bObjects)
+		object, _ := boltGetObject(tx, id)
+		if nil == object {
 			return nil
 		}
 
-		// We need to read the object to cleanup the index
-		var object APIObject
-		if err := json.Unmarshal(v, &object); nil != err {
-			panic(err)
-		}
 		b.Delete([]byte(id))
 
 		// Remove object ids from the index
-		b = tx.Bucket([]byte("idx_api_objects_by_parent"))
+		b = tx.Bucket(bParents)
 		for _, parent := range object.Parents {
 			b.Delete([]byte(parent + "/" + object.Name))
 		}
@@ -241,30 +227,8 @@ func (c *Cache) DeleteObject(id string) error {
 
 // UpdateObject updates an object
 func (c *Cache) UpdateObject(object *APIObject) error {
-	if err := c.DeleteObject(object.ObjectID); nil != err {
-		return err
-	}
-	v, err := json.Marshal(object)
-	if err != nil {
-		Log.Debugf("%v", err)
-		return fmt.Errorf("Could not marshal object %v (%v)", object.ObjectID, object.Name)
-	}
-
-	err = c.db.Update(func(tx *bolt.Tx) error {
-		// Store the object in the cache by id
-		b := tx.Bucket([]byte("api_objects"))
-		if err := b.Put([]byte(object.ObjectID), v); nil != err {
-			return err
-		}
-
-		// Store the object id by parent-name in the the index
-		b = tx.Bucket([]byte("idx_api_objects_by_parent"))
-		for _, parent := range object.Parents {
-			if err := b.Put([]byte(parent+"/"+object.Name), []byte(object.ObjectID)); nil != err {
-				return err
-			}
-		}
-		return nil
+	err := c.db.Update(func(tx *bolt.Tx) error {
+		return boltUpdateObject(tx, object)
 	})
 
 	if nil != err {
@@ -275,11 +239,74 @@ func (c *Cache) UpdateObject(object *APIObject) error {
 	return nil
 }
 
+func boltStoreObject(tx *bolt.Tx, object *APIObject) error {
+	b := tx.Bucket(bObjects)
+	v, err := json.Marshal(object)
+	if nil != err {
+		return err
+	}
+	return b.Put([]byte(object.ObjectID), v)
+}
+
+func boltGetObject(tx *bolt.Tx, id string) (*APIObject, error) {
+	b := tx.Bucket(bObjects)
+	v := b.Get([]byte(id))
+	if v == nil {
+		return nil, fmt.Errorf("Could not find object %v in cache", id)
+	}
+
+	var object APIObject
+	err := json.Unmarshal(v, &object)
+	return &object, err
+}
+
+func boltUpdateObject(tx *bolt.Tx, object *APIObject) error {
+	prev, _ := boltGetObject(tx, object.ObjectID)
+	if nil != prev {
+		// Remove object ids from the index
+		b := tx.Bucket(bParents)
+		for _, parent := range object.Parents {
+			b.Delete([]byte(parent + "/" + object.Name))
+		}
+	}
+
+	if err := boltStoreObject(tx, object); nil != err {
+		return err
+	}
+
+	// Store the object id by parent-name in the index
+	b := tx.Bucket(bParents)
+	for _, parent := range object.Parents {
+		if err := b.Put([]byte(parent+"/"+object.Name), []byte(object.ObjectID)); nil != err {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Cache) BatchUpdateObjects(objects []*APIObject) error {
+	err := c.db.Update(func(tx *bolt.Tx) error {
+		for _, object := range objects {
+			if err := boltUpdateObject(tx, object); nil != err {
+				return err
+			}
+		}
+		return nil
+	})
+
+	if nil != err {
+		Log.Debugf("%v", err)
+		return fmt.Errorf("Could not update/save objects: %v", err)
+	}
+
+	return nil
+}
+
 // StoreStartPageToken stores the page token for changes
 func (c *Cache) StoreStartPageToken(token string) error {
 	Log.Debugf("Storing page token %v in cache", token)
 	err := c.db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("page_token"))
+		b := tx.Bucket(bPageToken)
 		return b.Put([]byte("t"), []byte(token))
 	})
 
@@ -297,7 +324,7 @@ func (c *Cache) GetStartPageToken() (string, error) {
 
 	Log.Debugf("Getting start page token from cache")
 	c.db.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("page_token"))
+		b := tx.Bucket(bPageToken)
 		v := b.Get([]byte("t"))
 		pageToken = string(v)
 		return nil

--- a/drive.go
+++ b/drive.go
@@ -113,6 +113,7 @@ func (d *Drive) checkChanges(firstCheck bool) {
 			break
 		}
 
+		objects := make([]*APIObject, 0)
 		for _, change := range results.Changes {
 			Log.Tracef("Change %v", change)
 
@@ -127,14 +128,15 @@ func (d *Drive) checkChanges(firstCheck bool) {
 					Log.Debugf("%v", err)
 					Log.Warningf("Could not map Google Drive file %v (%v) to object", change.File.Id, change.File.Name)
 				} else {
-					if err := d.cache.UpdateObject(object); nil != err {
-						Log.Warningf("%v", err)
-					}
+					objects = append(objects, object)
 					updatedItems++
 				}
 			}
 
 			processedItems++
+		}
+		if err := d.cache.BatchUpdateObjects(objects); nil != err {
+			Log.Warningf("%v", err)
 		}
 
 		if processedItems > 0 {

--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ func main() {
 		}
 	}
 
-	cache, err := NewCache(*argMongoURL, *argMongoUser, *argMongoPass, *argMongoDatabase, *argConfigPath, *argLogLevel > 3)
+	cache, err := NewCache(*argConfigPath)
 	if nil != err {
 		Log.Errorf("%v", err)
 		os.Exit(4)


### PR DESCRIPTION
Hi,

Thanks for your great project. I didn't want to set up an external server for such a simple project, so I chose to replace MongoDB with [Bolt](https://github.com/boltdb/bolt) - which is a fast, thread-safe embedded key-value store written in Go. I whipped this up in one evening and didn't test it extensively yet, but in general it should work. I'll be running it on my server for the next weeks.

I'm submitting it here to gauge interest and get a bit of feedback, so please let me know if you are interested in merging this and I'll see if I can improve this.

Also, I didn't conduct any benchmarking - and never tested with MongoDB before, so I'm not sure of the performance differences. Bolt in general should be very fast when reading, but I didn't optimize my code for writing lots of randomly distributed KV pairs, and the initial sync seems to take a while on a spinning drive with 3 TB of GDrive data.

Bolt operates on byte slices only, so I chose the following DB layout:

* api_objects: ID as key, JSON-encoded APIObject as value
* idx_api_objects_by_parent: `parent/name` as key, object ID as value
* page_token: "t" as key, token string as value