### PR TITLE
Add Team Drive Support

### DIFF
--- a/drive/drive.go
+++ b/drive/drive.go
@@ -106,11 +106,10 @@ func (d *Client) checkChanges(firstCheck bool) {
 			List(pageToken).
 			Fields(googleapi.Field(fmt.Sprintf("nextPageToken, newStartPageToken, changes(removed, fileId, file(%v))", Fields))).
 			PageSize(1000).
-			//TeamDriveId(d.rootNodeID).
 			SupportsTeamDrives(true).
 			IncludeTeamDriveItems(true)
 
-		if d.rootNodeID != "root"{
+		if d.rootNodeID != "root" {
 			query = query.TeamDriveId(d.rootNodeID)
 		}
 

--- a/drive/drive.go
+++ b/drive/drive.go
@@ -105,7 +105,14 @@ func (d *Client) checkChanges(firstCheck bool) {
 		query := client.Changes.
 			List(pageToken).
 			Fields(googleapi.Field(fmt.Sprintf("nextPageToken, newStartPageToken, changes(removed, fileId, file(%v))", Fields))).
-			PageSize(1000)
+			PageSize(1000).
+			//TeamDriveId(d.rootNodeID).
+			SupportsTeamDrives(true).
+			IncludeTeamDriveItems(true)
+
+		if d.rootNodeID != "root"{
+			query = query.TeamDriveId(d.rootNodeID)
+		}
 
 		results, err := query.Do()
 		if nil != err {
@@ -117,6 +124,10 @@ func (d *Client) checkChanges(firstCheck bool) {
 		objects := make([]*APIObject, 0)
 		for _, change := range results.Changes {
 			Log.Tracef("Change %v", change)
+			if nil == change.File {
+				Log.Warningf("Skipping nil file")
+				continue
+			}
 
 			if change.Removed || (nil != change.File && change.File.ExplicitlyTrashed) {
 				if err := d.cache.DeleteObject(change.FileId); nil != err {
@@ -226,6 +237,7 @@ func (d *Client) GetRoot() (*APIObject, error) {
 	file, err := client.Files.
 		Get(d.rootNodeID).
 		Fields(googleapi.Field(Fields)).
+		SupportsTeamDrives(true).
 		Do()
 	if nil != err {
 		Log.Debugf("%v", err)
@@ -234,7 +246,7 @@ func (d *Client) GetRoot() (*APIObject, error) {
 
 	// getting file size
 	if file.MimeType != "application/vnd.google-apps.folder" && 0 == file.Size {
-		res, err := client.Files.Get(d.rootNodeID).Download()
+		res, err := client.Files.Get(d.rootNodeID).SupportsTeamDrives(true).Download()
 		if nil != err {
 			Log.Debugf("%v", err)
 			return nil, fmt.Errorf("Could not get file size for object %v", d.rootNodeID)
@@ -275,13 +287,13 @@ func (d *Client) Remove(object *APIObject, parent string) error {
 
 	go func() {
 		if object.CanTrash {
-			if _, err := client.Files.Update(object.ObjectID, &gdrive.File{Trashed: true}).Do(); nil != err {
+			if _, err := client.Files.Update(object.ObjectID, &gdrive.File{Trashed: true}).SupportsTeamDrives(true).Do(); nil != err {
 				Log.Debugf("%v", err)
 				Log.Warningf("Could not delete object %v (%v) from API", object.ObjectID, object.Name)
 				d.cache.UpdateObject(object)
 			}
 		} else {
-			if _, err := client.Files.Update(object.ObjectID, nil).RemoveParents(parent).Do(); nil != err {
+			if _, err := client.Files.Update(object.ObjectID, nil).RemoveParents(parent).SupportsTeamDrives(true).Do(); nil != err {
 				Log.Debugf("%v", err)
 				Log.Warningf("Could not unsubscribe object %v (%v) from API", object.ObjectID, object.Name)
 				d.cache.UpdateObject(object)
@@ -300,13 +312,13 @@ func (d *Client) Mkdir(parent string, Name string) (*APIObject, error) {
 		return nil, fmt.Errorf("Could not get Google Drive client")
 	}
 
-	created, err := client.Files.Create(&gdrive.File{Name: Name, Parents: []string{parent}, MimeType: "application/vnd.google-apps.folder"}).Do()
+	created, err := client.Files.Create(&gdrive.File{Name: Name, Parents: []string{parent}, MimeType: "application/vnd.google-apps.folder"}).SupportsTeamDrives(true).Do()
 	if nil != err {
 		Log.Debugf("%v", err)
 		return nil, fmt.Errorf("Could not create object(%v) from API", Name)
 	}
 
-	file, err := client.Files.Get(created.Id).Fields(googleapi.Field(Fields)).Do()
+	file, err := client.Files.Get(created.Id).Fields(googleapi.Field(Fields)).SupportsTeamDrives(true).Do()
 	if nil != err {
 		Log.Debugf("%v", err)
 		return nil, fmt.Errorf("Could not get object fields %v from API", created.Id)
@@ -334,7 +346,7 @@ func (d *Client) Rename(object *APIObject, OldParent string, NewParent string, N
 		return fmt.Errorf("Could not get Google Drive client")
 	}
 
-	if _, err := client.Files.Update(object.ObjectID, &gdrive.File{Name: NewName}).RemoveParents(OldParent).AddParents(NewParent).Do(); nil != err {
+	if _, err := client.Files.Update(object.ObjectID, &gdrive.File{Name: NewName}).RemoveParents(OldParent).AddParents(NewParent).SupportsTeamDrives(true).Do(); nil != err {
 		Log.Debugf("%v", err)
 		return fmt.Errorf("Could not rename object %v (%v) from API", object.ObjectID, object.Name)
 	}


### PR DESCRIPTION
Added Team Drive Support. Tested and working on Mac OS 10.14 and Ubuntu 16.04. 

Need to specify --root-node-id for the team drive. If not specified, it works normally with the root folder of the drive.