### PR TITLE
Update build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
 go:
-  - 1.8
+  - 1.9
   - 1.12
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: go
 go:
   - 1.9
   - 1.12
-  - master
+  - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
 go:
-  - 1.7
   - 1.8
+  - 1.12
   - master


### PR DESCRIPTION
Both golang 1.7 and 1.8 builds on Travis CI fail with current versions of the dependencies.

Bump minimum golang version for Travis CI to 1.9, add 1.12 and replace master with stable.