### PR TITLE
Remove allow_root mount option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 
 go:
-  - 1.9
-  - 1.12
+  - 1.13
   - stable

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -49,7 +49,7 @@ func Mount(
 		if "allow_other" == option {
 			options = append(options, fuse.AllowOther())
 		} else if "allow_root" == option {
-			options = append(options, fuse.AllowRoot())
+			return fmt.Errorf("The allow_root mount option is no longer supported")
 		} else if "allow_dev" == option {
 			options = append(options, fuse.AllowDev())
 		} else if "allow_non_empty_mount" == option {


### PR DESCRIPTION
This is no longer supported, because fuse.AllowRoot() was removed in https://github.com/bazil/fuse/commit/e0b89709bc6481f1345b6e19363cf18766e53fc7.

Fixes #339