### PR TITLE
Team Drive Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Usage of ./plexdrive mount:
     	The size of each chunk that is downloaded (units: B, K, M, G) (default "10M")
   -c, --config string
     	The path to the configuration directory (default "~/.plexdrive")
+  --drive-id string
+    	The ID of the shared drive to mount (including team drives)
   -o, --fuse-options string
     	Fuse mount options (e.g. -fuse-options allow_other,...)
   --gid int
@@ -90,11 +92,11 @@ Don't expect any performance improvement or something else. This option is only 
 personal folder structuring.
 
 #### Team Drive
-You can pass the ID of a Team Drive as `root-node-id` to get access to a Team drive, here's how:
+You can pass the ID of a Team Drive as `drive-id` to get access to a Team drive, here's how:
 * Open the Team Drive in your browser
 * Note the format of the URL: https://drive.google.com/drive/u/0/folders/ABC123qwerty987
-* The `root-node-id` of this Team Drive is `ABC123qwerty987`
-* Pass it with `--root-node-id=ABC123qwerty987` argument to your `plexdrive mount` command
+* The `drive-id` of this Team Drive is `ABC123qwerty987`
+* Pass it with `--drive-id=ABC123qwerty987` argument to your `plexdrive mount` command
 
 # Contribute
 If you want to support the project by implementing functions / fixing bugs

--- a/drive/drive.go
+++ b/drive/drive.go
@@ -28,11 +28,12 @@ type Client struct {
 	token           *oauth2.Token
 	config          *oauth2.Config
 	rootNodeID      string
+	driveID         string
 	changesChecking bool
 }
 
 // NewClient creates a new Google Drive client
-func NewClient(config *config.Config, cache *Cache, refreshInterval time.Duration, rootNodeID string) (*Client, error) {
+func NewClient(config *config.Config, cache *Cache, refreshInterval time.Duration, rootNodeID string, driveID string) (*Client, error) {
 	client := Client{
 		cache:   cache,
 		context: context.Background(),
@@ -47,11 +48,15 @@ func NewClient(config *config.Config, cache *Cache, refreshInterval time.Duratio
 			Scopes:      []string{gdrive.DriveScope},
 		},
 		rootNodeID:      rootNodeID,
+		driveID:         driveID,
 		changesChecking: false,
 	}
 
 	if "" == client.rootNodeID {
 		client.rootNodeID = "root"
+	}
+	if "" != client.driveID && client.rootNodeID == "root" {
+		client.rootNodeID = client.driveID
 	}
 
 	if err := client.authorize(); nil != err {
@@ -109,8 +114,8 @@ func (d *Client) checkChanges(firstCheck bool) {
 			SupportsTeamDrives(true).
 			IncludeTeamDriveItems(true)
 
-		if d.rootNodeID != "root" {
-			query = query.TeamDriveId(d.rootNodeID)
+		if d.driveID != "" {
+			query = query.TeamDriveId(d.driveID)
 		}
 
 		results, err := query.Do()

--- a/drive/drive.go
+++ b/drive/drive.go
@@ -111,8 +111,8 @@ func (d *Client) checkChanges(firstCheck bool) {
 			List(pageToken).
 			Fields(googleapi.Field(fmt.Sprintf("nextPageToken, newStartPageToken, changes(changeType, removed, fileId, file(%v))", Fields))).
 			PageSize(1000).
-			SupportsTeamDrives(true).
-			IncludeTeamDriveItems(true).
+			SupportsAllDrives(true).
+			IncludeItemsFromAllDrives(true).
 			IncludeCorpusRemovals(true)
 
 		if d.driveID != "" {
@@ -243,7 +243,7 @@ func (d *Client) GetRoot() (*APIObject, error) {
 	file, err := client.Files.
 		Get(d.rootNodeID).
 		Fields(googleapi.Field(Fields)).
-		SupportsTeamDrives(true).
+		SupportsAllDrives(true).
 		Do()
 	if nil != err {
 		Log.Debugf("%v", err)
@@ -252,7 +252,7 @@ func (d *Client) GetRoot() (*APIObject, error) {
 
 	// getting file size
 	if file.MimeType != "application/vnd.google-apps.folder" && 0 == file.Size {
-		res, err := client.Files.Get(d.rootNodeID).SupportsTeamDrives(true).Download()
+		res, err := client.Files.Get(d.rootNodeID).SupportsAllDrives(true).Download()
 		if nil != err {
 			Log.Debugf("%v", err)
 			return nil, fmt.Errorf("Could not get file size for object %v", d.rootNodeID)
@@ -293,13 +293,13 @@ func (d *Client) Remove(object *APIObject, parent string) error {
 
 	go func() {
 		if object.CanTrash {
-			if _, err := client.Files.Update(object.ObjectID, &gdrive.File{Trashed: true}).SupportsTeamDrives(true).Do(); nil != err {
+			if _, err := client.Files.Update(object.ObjectID, &gdrive.File{Trashed: true}).SupportsAllDrives(true).Do(); nil != err {
 				Log.Debugf("%v", err)
 				Log.Warningf("Could not delete object %v (%v) from API", object.ObjectID, object.Name)
 				d.cache.UpdateObject(object)
 			}
 		} else {
-			if _, err := client.Files.Update(object.ObjectID, nil).RemoveParents(parent).SupportsTeamDrives(true).Do(); nil != err {
+			if _, err := client.Files.Update(object.ObjectID, nil).RemoveParents(parent).SupportsAllDrives(true).Do(); nil != err {
 				Log.Debugf("%v", err)
 				Log.Warningf("Could not unsubscribe object %v (%v) from API", object.ObjectID, object.Name)
 				d.cache.UpdateObject(object)
@@ -318,13 +318,13 @@ func (d *Client) Mkdir(parent string, Name string) (*APIObject, error) {
 		return nil, fmt.Errorf("Could not get Google Drive client")
 	}
 
-	created, err := client.Files.Create(&gdrive.File{Name: Name, Parents: []string{parent}, MimeType: "application/vnd.google-apps.folder"}).SupportsTeamDrives(true).Do()
+	created, err := client.Files.Create(&gdrive.File{Name: Name, Parents: []string{parent}, MimeType: "application/vnd.google-apps.folder"}).SupportsAllDrives(true).Do()
 	if nil != err {
 		Log.Debugf("%v", err)
 		return nil, fmt.Errorf("Could not create object(%v) from API", Name)
 	}
 
-	file, err := client.Files.Get(created.Id).Fields(googleapi.Field(Fields)).SupportsTeamDrives(true).Do()
+	file, err := client.Files.Get(created.Id).Fields(googleapi.Field(Fields)).SupportsAllDrives(true).Do()
 	if nil != err {
 		Log.Debugf("%v", err)
 		return nil, fmt.Errorf("Could not get object fields %v from API", created.Id)
@@ -352,7 +352,7 @@ func (d *Client) Rename(object *APIObject, OldParent string, NewParent string, N
 		return fmt.Errorf("Could not get Google Drive client")
 	}
 
-	if _, err := client.Files.Update(object.ObjectID, &gdrive.File{Name: NewName}).RemoveParents(OldParent).AddParents(NewParent).SupportsTeamDrives(true).Do(); nil != err {
+	if _, err := client.Files.Update(object.ObjectID, &gdrive.File{Name: NewName}).RemoveParents(OldParent).AddParents(NewParent).SupportsAllDrives(true).Do(); nil != err {
 		Log.Debugf("%v", err)
 		return fmt.Errorf("Could not rename object %v (%v) from API", object.ObjectID, object.Name)
 	}

--- a/drive/drive.go
+++ b/drive/drive.go
@@ -109,10 +109,11 @@ func (d *Client) checkChanges(firstCheck bool) {
 	for {
 		query := client.Changes.
 			List(pageToken).
-			Fields(googleapi.Field(fmt.Sprintf("nextPageToken, newStartPageToken, changes(removed, fileId, file(%v))", Fields))).
+			Fields(googleapi.Field(fmt.Sprintf("nextPageToken, newStartPageToken, changes(changeType, removed, fileId, file(%v))", Fields))).
 			PageSize(1000).
 			SupportsTeamDrives(true).
-			IncludeTeamDriveItems(true)
+			IncludeTeamDriveItems(true).
+			IncludeCorpusRemovals(true)
 
 		if d.driveID != "" {
 			query = query.TeamDriveId(d.driveID)
@@ -128,8 +129,9 @@ func (d *Client) checkChanges(firstCheck bool) {
 		objects := make([]*APIObject, 0)
 		for _, change := range results.Changes {
 			Log.Tracef("Change %v", change)
-			if nil == change.File {
-				Log.Warningf("Skipping nil file")
+			// ignore changes for changeType drive
+			if change.ChangeType != "file" {
+				Log.Warningf("Ignoring change type %v", change.ChangeType)
 				continue
 			}
 

--- a/main.go
+++ b/main.go
@@ -32,20 +32,21 @@ func main() {
 	usr, err := user.Current()
 	home := ""
 	if err != nil {
-	    // Fall back to reading $HOME - work around user.Current() not
-	    // working for cross compiled binaries on OSX or freebsd.
-	    // https://github.com/golang/go/issues/6376
-	    home = os.Getenv("HOME")
-	    if home == "" {
-	    	panic(fmt.Sprintf("Could not read users homedir and HOME is not set: %v\n", err))
-	    }
+		// Fall back to reading $HOME - work around user.Current() not
+		// working for cross compiled binaries on OSX or freebsd.
+		// https://github.com/golang/go/issues/6376
+		home = os.Getenv("HOME")
+		if home == "" {
+			panic(fmt.Sprintf("Could not read users homedir and HOME is not set: %v\n", err))
+		}
 	} else {
-	    home = usr.HomeDir
+		home = usr.HomeDir
 	}
 
 	// parse the command line arguments
 	argLogLevel := flag.IntP("verbosity", "v", 0, "Set the log level (0 = error, 1 = warn, 2 = info, 3 = debug, 4 = trace)")
 	argRootNodeID := flag.String("root-node-id", "root", "The ID of the root node to mount (use this for only mount a sub directory)")
+	argDriveID := flag.String("drive-id", "", "The ID of the team drive to mount")
 	argConfigPath := flag.StringP("config", "c", filepath.Join(home, ".plexdrive"), "The path to the configuration directory")
 	argCacheFile := flag.String("cache-file", filepath.Join(home, ".plexdrive", "cache.bolt"), "Path the the cache file")
 	argChunkSize := flag.String("chunk-size", "10M", "The size of each chunk that is downloaded (units: B, K, M, G)")
@@ -119,6 +120,7 @@ func main() {
 		// debug all given parameters
 		Log.Debugf("verbosity            : %v", logLevel)
 		Log.Debugf("root-node-id         : %v", *argRootNodeID)
+		Log.Debugf("drive-id             : %v", *argDriveID)
 		Log.Debugf("config               : %v", *argConfigPath)
 		Log.Debugf("cache-file           : %v", *argCacheFile)
 		Log.Debugf("chunk-size           : %v", *argChunkSize)
@@ -172,7 +174,7 @@ func main() {
 		}
 		defer cache.Close()
 
-		client, err := drive.NewClient(cfg, cache, *argRefreshInterval, *argRootNodeID)
+		client, err := drive.NewClient(cfg, cache, *argRefreshInterval, *argRootNodeID, *argDriveID)
 		if nil != err {
 			Log.Errorf("%v", err)
 			os.Exit(4)

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 	// parse the command line arguments
 	argLogLevel := flag.IntP("verbosity", "v", 0, "Set the log level (0 = error, 1 = warn, 2 = info, 3 = debug, 4 = trace)")
 	argRootNodeID := flag.String("root-node-id", "root", "The ID of the root node to mount (use this for only mount a sub directory)")
-	argDriveID := flag.String("drive-id", "", "The ID of the team drive to mount")
+	argDriveID := flag.String("drive-id", "", "The ID of the shared drive to mount (including team drives)")
 	argConfigPath := flag.StringP("config", "c", filepath.Join(home, ".plexdrive"), "The path to the configuration directory")
 	argCacheFile := flag.String("cache-file", filepath.Join(home, ".plexdrive", "cache.bolt"), "Path the the cache file")
 	argChunkSize := flag.String("chunk-size", "10M", "The size of each chunk that is downloaded (units: B, K, M, G)")


### PR DESCRIPTION
This fixes a couple of problems with the Team Drive support:

* Team Drive support now uses a new option `--drive-id` instead of overloading the `--root-node-id` option, which fixes #334 and makes `--root-node-id` work with subfolders of a team drive.
* Ignore change records of type "drive" and always include the file resource on change records for removals.
* Update drive API calls for shared drives to remove deprecated usage (the new calls are also deprecated some time in 2020, at which time shared drives are always included).