### PR TITLE
Reuse download buffers

### DIFF
--- a/chunk/download.go
+++ b/chunk/download.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -14,20 +15,22 @@ import (
 
 // Downloader handles concurrent chunk downloads
 type Downloader struct {
-	Client    *drive.Client
-	queue     chan *Request
-	callbacks map[string][]DownloadCallback
-	lock      sync.Mutex
+	Client     *drive.Client
+	BufferSize int64
+	queue      chan *Request
+	callbacks  map[string][]DownloadCallback
+	lock       sync.Mutex
 }
 
 type DownloadCallback func(error, []byte)
 
 // NewDownloader creates a new download manager
-func NewDownloader(threads int, client *drive.Client) (*Downloader, error) {
+func NewDownloader(threads int, client *drive.Client, bufferSize int64) (*Downloader, error) {
 	manager := Downloader{
-		Client:    client,
-		queue:     make(chan *Request, 100),
-		callbacks: make(map[string][]DownloadCallback, 100),
+		Client:     client,
+		BufferSize: bufferSize,
+		queue:      make(chan *Request, 100),
+		callbacks:  make(map[string][]DownloadCallback, 100),
 	}
 
 	for i := 0; i < threads; i++ {
@@ -49,26 +52,27 @@ func (d *Downloader) Download(req *Request, callback DownloadCallback) {
 }
 
 func (d *Downloader) thread() {
+	buffer := make([]byte, d.BufferSize)
 	for {
 		req := <-d.queue
-		d.download(d.Client.GetNativeClient(), req)
+		d.download(d.Client.GetNativeClient(), req, buffer)
 	}
 }
 
-func (d *Downloader) download(client *http.Client, req *Request) {
+func (d *Downloader) download(client *http.Client, req *Request, buffer []byte) {
 	Log.Debugf("Starting download %v (preload: %v)", req.id, req.preload)
-	bytes, err := downloadFromAPI(client, req, 0)
+	err := downloadFromAPI(client, req, buffer, 0)
 
 	d.lock.Lock()
 	callbacks := d.callbacks[req.id]
 	for _, callback := range callbacks {
-		callback(err, bytes)
+		callback(err, buffer)
 	}
 	delete(d.callbacks, req.id)
 	d.lock.Unlock()
 }
 
-func downloadFromAPI(client *http.Client, request *Request, delay int64) ([]byte, error) {
+func downloadFromAPI(client *http.Client, request *Request, buffer []byte, delay int64) error {
 	// sleep if request is throttled
 	if delay > 0 {
 		time.Sleep(time.Duration(delay) * time.Second)
@@ -77,7 +81,7 @@ func downloadFromAPI(client *http.Client, request *Request, delay int64) ([]byte
 	req, err := http.NewRequest("GET", request.object.DownloadURL, nil)
 	if nil != err {
 		Log.Debugf("%v", err)
-		return nil, fmt.Errorf("Could not create request object %v (%v) from API", request.object.ObjectID, request.object.Name)
+		return fmt.Errorf("Could not create request object %v (%v) from API", request.object.ObjectID, request.object.Name)
 	}
 
 	req.Header.Add("Range", fmt.Sprintf("bytes=%v-%v", request.offsetStart, request.offsetEnd-1))
@@ -87,7 +91,7 @@ func downloadFromAPI(client *http.Client, request *Request, delay int64) ([]byte
 	res, err := client.Do(req)
 	if nil != err {
 		Log.Debugf("%v", err)
-		return nil, fmt.Errorf("Could not request object %v (%v) from API", request.object.ObjectID, request.object.Name)
+		return fmt.Errorf("Could not request object %v (%v) from API", request.object.ObjectID, request.object.Name)
 	}
 	defer res.Body.Close()
 	reader := res.Body
@@ -96,17 +100,17 @@ func downloadFromAPI(client *http.Client, request *Request, delay int64) ([]byte
 		if res.StatusCode != 403 && res.StatusCode != 500 {
 			Log.Debugf("Request\n----------\n%v\n----------\n", req)
 			Log.Debugf("Response\n----------\n%v\n----------\n", res)
-			return nil, fmt.Errorf("Wrong status code %v for %v", res.StatusCode, request.object)
+			return fmt.Errorf("Wrong status code %v for %v", res.StatusCode, request.object)
 		}
 
 		// throttle requests
 		if delay > 8 {
-			return nil, fmt.Errorf("Maximum throttle interval has been reached")
+			return fmt.Errorf("Maximum throttle interval has been reached")
 		}
 		bytes, err := ioutil.ReadAll(reader)
 		if nil != err {
 			Log.Debugf("%v", err)
-			return nil, fmt.Errorf("Could not read body of error")
+			return fmt.Errorf("Could not read body of error")
 		}
 		body := string(bytes)
 		if strings.Contains(body, "dailyLimitExceeded") ||
@@ -119,20 +123,25 @@ func downloadFromAPI(client *http.Client, request *Request, delay int64) ([]byte
 			} else {
 				delay = delay * 2
 			}
-			return downloadFromAPI(client, request, delay)
+			return downloadFromAPI(client, request, buffer, delay)
 		}
 
 		// return an error if other error occurred
 		Log.Debugf("%v", body)
-		return nil, fmt.Errorf("Could not read object %v (%v) / StatusCode: %v",
+		return fmt.Errorf("Could not read object %v (%v) / StatusCode: %v",
 			request.object.ObjectID, request.object.Name, res.StatusCode)
 	}
 
-	bytes, err := ioutil.ReadAll(reader)
-	if nil != err {
-		Log.Debugf("%v", err)
-		return nil, fmt.Errorf("Could not read objects %v (%v) API response", request.object.ObjectID, request.object.Name)
+	if res.ContentLength == -1 {
+		return fmt.Errorf("Missing Content-Length header in response")
 	}
 
-	return bytes, nil
+	n, err := io.ReadFull(reader, buffer[:res.ContentLength:cap(buffer)])
+	if nil != err {
+		Log.Debugf("%v", err)
+		return fmt.Errorf("Could not read objects %v (%v) API response", request.object.ObjectID, request.object.Name)
+	}
+	Log.Debugf("Downloaded %v bytes of %v (%v)", n, request.object.ObjectID, request.object.Name)
+
+	return nil
 }

--- a/chunk/manager.go
+++ b/chunk/manager.go
@@ -60,7 +60,7 @@ func NewManager(
 		return nil, fmt.Errorf("max-chunks must be greater than 2 and bigger than the load ahead value")
 	}
 
-	downloader, err := NewDownloader(loadThreads, client)
+	downloader, err := NewDownloader(loadThreads, client, chunkSize)
 	if nil != err {
 		return nil, err
 	}


### PR DESCRIPTION
This reduces stress on the garbage collector and ultimately memory usage by using a fixed download buffer for each downloader thread.