### PR TITLE
Fix acknowledge abuse download of unflagged files

### DIFF
--- a/chunk/download.go
+++ b/chunk/download.go
@@ -75,7 +75,7 @@ func (d *Downloader) thread(n int) {
 
 func (d *Downloader) download(client *http.Client, req *Request, buffer []byte) {
 	Log.Debugf("Starting download %v (preload: %v)", req.id, req.preload)
-	err := d.downloadFromAPI(client, req, buffer, 0)
+	err := d.downloadFromAPI(client, req, buffer, 0, false)
 
 	d.lock.Lock()
 	callbacks := d.callbacks[req.id]
@@ -94,14 +94,14 @@ func (d *Downloader) download(client *http.Client, req *Request, buffer []byte) 
 	}
 }
 
-func (d *Downloader) downloadFromAPI(client *http.Client, request *Request, buffer []byte, delay int64) error {
+func (d *Downloader) downloadFromAPI(client *http.Client, request *Request, buffer []byte, delay int64, ackAbuse bool) error {
 	// sleep if request is throttled
 	if delay > 0 {
 		time.Sleep(time.Duration(delay) * time.Second)
 	}
 
 	downloadURL := request.object.DownloadURL
-	if d.acknowledgeAbuse {
+	if ackAbuse {
 		downloadURL += "&acknowledgeAbuse=true"
 	}
 	req, err := http.NewRequest("GET", downloadURL, nil)
@@ -138,6 +138,10 @@ func (d *Downloader) downloadFromAPI(client *http.Client, request *Request, buff
 			return fmt.Errorf("Could not read body of error")
 		}
 		body := string(bytes)
+		// if denied because of abuse, retry download with acknowledgeAbuse=true
+		if d.acknowledgeAbuse && !ackAbuse && strings.Contains(body, "cannotDownloadAbusiveFile") {
+			return d.downloadFromAPI(client, request, buffer, delay, true)
+		}
 		if strings.Contains(body, "dailyLimitExceeded") ||
 			strings.Contains(body, "userRateLimitExceeded") ||
 			strings.Contains(body, "rateLimitExceeded") ||
@@ -148,7 +152,7 @@ func (d *Downloader) downloadFromAPI(client *http.Client, request *Request, buff
 			} else {
 				delay = delay * 2
 			}
-			return d.downloadFromAPI(client, request, buffer, delay)
+			return d.downloadFromAPI(client, request, buffer, delay, ackAbuse)
 		}
 
 		// return an error if other error occurred

--- a/chunk/download.go
+++ b/chunk/download.go
@@ -18,18 +18,19 @@ import (
 
 // Downloader handles concurrent chunk downloads
 type Downloader struct {
-	Client     *drive.Client
-	BufferSize int64
-	queue      chan *Request
-	callbacks  map[RequestID][]DownloadCallback
-	lock       sync.Mutex
-	storage    *Storage
+	Client           *drive.Client
+	BufferSize       int64
+	queue            chan *Request
+	callbacks        map[RequestID][]DownloadCallback
+	lock             sync.Mutex
+	storage          *Storage
+	acknowledgeAbuse bool
 }
 
 type DownloadCallback func(error, []byte)
 
 // NewDownloader creates a new download manager
-func NewDownloader(threads int, client *drive.Client, storage *Storage, bufferSize int64) (*Downloader, error) {
+func NewDownloader(threads int, client *drive.Client, storage *Storage, bufferSize int64, acknowledgeAbuse bool) (*Downloader, error) {
 	manager := Downloader{
 		Client:     client,
 		BufferSize: bufferSize,
@@ -74,7 +75,7 @@ func (d *Downloader) thread(n int) {
 
 func (d *Downloader) download(client *http.Client, req *Request, buffer []byte) {
 	Log.Debugf("Starting download %v (preload: %v)", req.id, req.preload)
-	err := downloadFromAPI(client, req, buffer, 0)
+	err := d.downloadFromAPI(client, req, buffer, 0)
 
 	d.lock.Lock()
 	callbacks := d.callbacks[req.id]
@@ -93,14 +94,14 @@ func (d *Downloader) download(client *http.Client, req *Request, buffer []byte) 
 	}
 }
 
-func downloadFromAPI(client *http.Client, request *Request, buffer []byte, delay int64) error {
+func (d *Downloader) downloadFromAPI(client *http.Client, request *Request, buffer []byte, delay int64) error {
 	// sleep if request is throttled
 	if delay > 0 {
 		time.Sleep(time.Duration(delay) * time.Second)
 	}
 
 	downloadURL := request.object.DownloadURL
-	if request.acknowledgeAbuse {
+	if d.acknowledgeAbuse {
 		downloadURL += "&acknowledgeAbuse=true"
 	}
 	req, err := http.NewRequest("GET", downloadURL, nil)
@@ -147,7 +148,7 @@ func downloadFromAPI(client *http.Client, request *Request, buffer []byte, delay
 			} else {
 				delay = delay * 2
 			}
-			return downloadFromAPI(client, request, buffer, delay)
+			return d.downloadFromAPI(client, request, buffer, delay)
 		}
 
 		// return an error if other error occurred


### PR DESCRIPTION
Currently, when the `--acknowledge-abuse` flag is given, plexdrive can _only_ download abused files, files not flagged for abuse fail to download with the error "invalidAbuseAcknowledoment".

This PR tries to fix that by only adding the `acknowledgeAbuse=true` parameter to the download URL, if the `--acknowledge-abuse` was given and the download request failed with the "cannotDownloadAbusiveFile" error.

The drawback is that we do twice as many download requests for abused files, but a better solution would require to cache the abuse state of a file in the drive object metadata inside cache.bolt, which would require a lot more code changes.

Unrelated to the fix I've also moved the global acknowledgeAbuse option flag to be passed directly to the Downloader instance, instead of repeating it in each Request struct.